### PR TITLE
Implement IndexedDB storage and search popup

### DIFF
--- a/contents/chatgpt/index.ts
+++ b/contents/chatgpt/index.ts
@@ -1,5 +1,6 @@
 import type { PlasmoCSConfig } from "plasmo"
 
+import { addMessage } from "~db"
 import { messageToSnapshot, type ConversationSnapshot } from "~models"
 
 import { getChatgptConversationId } from "./id"
@@ -11,8 +12,14 @@ export const config: PlasmoCSConfig = {
   matches: ["https://chatgpt.com/*", "https://chat.openai.com/*"]
 }
 
-const emitCapture = () => {
+const emitCapture = async () => {
   const messages = getChatgptDocumentMessages()
+  for (const m of messages) {
+    if (m.role === "user" || m.role === "assistant") {
+      const text = m.element?.innerText ?? ""
+      await addMessage(m.role, text, window.location.href)
+    }
+  }
   const detail: ConversationSnapshot = {
     id: getChatgptConversationId(),
     vendor: "openai",

--- a/db.ts
+++ b/db.ts
@@ -1,0 +1,63 @@
+import { openDB, type DBSchema } from "idb"
+import { v4 as uuid } from "uuid"
+
+import type { Conversation, Message } from "./types"
+
+interface AHSchema extends DBSchema {
+  conversations: {
+    key: string
+    value: Conversation
+    indexes: { byUrl: string }
+  }
+  messages: {
+    key: string
+    value: Message
+    indexes: { byConv: string; byContent: string }
+  }
+}
+
+export const dbPromise = openDB<AHSchema>("ag-herder", 1, {
+  upgrade(db) {
+    const conv = db.createObjectStore("conversations", { keyPath: "id" })
+    conv.createIndex("byUrl", "url", { unique: false })
+
+    const msg = db.createObjectStore("messages", { keyPath: "id" })
+    msg.createIndex("byConv", "conversationId")
+    msg.createIndex("byContent", "content", { unique: false })
+  }
+})
+
+export async function addMessage(
+  role: "user" | "assistant",
+  content: string,
+  conversationUrl: string
+) {
+  const db = await dbPromise
+
+  let convo = await db.getFromIndex("conversations", "byUrl", conversationUrl)
+  if (!convo) {
+    convo = {
+      id: uuid(),
+      url: conversationUrl,
+      createdAt: Date.now()
+    }
+    await db.add("conversations", convo)
+  }
+
+  const msg: Message = {
+    id: uuid(),
+    conversationId: convo.id,
+    role,
+    content,
+    createdAt: Date.now()
+  }
+  await db.add("messages", msg)
+}
+
+export async function searchMessages(query: string): Promise<Message[]> {
+  const db = await dbPromise
+  const all = await db.getAll("messages")
+  return all.filter((m) =>
+    m.content.toLowerCase().includes(query.toLowerCase())
+  )
+}

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "idb": "^8.0.3",
     "plasmo": "^0.90.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "uuid": "^11.1.0",
     "zod": "^3.25.74"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      idb:
+        specifier: ^8.0.3
+        version: 8.0.3
       plasmo:
         specifier: ^0.90.5
         version: 0.90.5(@swc/core@1.12.9(@swc/helpers@0.5.17))(@swc/helpers@0.5.17)(@types/node@22.16.0)(postcss@8.5.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -17,6 +20,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      uuid:
+        specifier: ^11.1.0
+        version: 11.1.0
       zod:
         specifier: ^3.25.74
         version: 3.25.74
@@ -2075,6 +2081,9 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
+  idb@8.0.3:
+    resolution: {integrity: sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -2969,6 +2978,10 @@ packages:
   utility-types@3.11.0:
     resolution: {integrity: sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==}
     engines: {node: '>= 4'}
+
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
 
   vue@3.3.4:
     resolution: {integrity: sha512-VTyEYn3yvIeY1Py0WaYGZsXnz3y5UnGi62GjVEqvEGPl6nxbOrCXbVOTQWBEJUqAyTUk2uJ5JLVnYJ6ZzGbrSw==}
@@ -5366,6 +5379,8 @@ snapshots:
       safer-buffer: 2.1.2
     optional: true
 
+  idb@8.0.3: {}
+
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
@@ -6255,6 +6270,8 @@ snapshots:
       picocolors: 1.1.1
 
   utility-types@3.11.0: {}
+
+  uuid@11.1.0: {}
 
   vue@3.3.4:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 onlyBuiltDependencies:
-  - '@parcel/watcher'
-  - '@swc/core'
+  - "@parcel/watcher"
+  - "@swc/core"
   - esbuild
   - lmdb
   - msgpackr-extract

--- a/popup.tsx
+++ b/popup.tsx
@@ -1,24 +1,38 @@
 import { useState } from "react"
 
+import { searchMessages } from "./db"
+import type { Message } from "./types"
+
 function IndexPopup() {
-  const [data, setData] = useState("")
+  const [query, setQuery] = useState("")
+  const [results, setResults] = useState<Message[]>([])
+
+  const onChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const q = e.target.value
+    setQuery(q)
+    const hits = await searchMessages(q)
+    setResults(hits)
+  }
+
+  const copyToClipboard = (content: string) => {
+    navigator.clipboard.writeText(content)
+  }
 
   return (
-    <div
-      style={{
-        padding: 16
-      }}>
-      <h2>
-        Welcome to your{" "}
-        <a href="https://www.plasmo.com" target="_blank">
-          Plasmo
-        </a>{" "}
-        Extension!
-      </h2>
-      <input onChange={(e) => setData(e.target.value)} value={data} />
-      <a href="https://docs.plasmo.com" target="_blank">
-        View Docs
-      </a>
+    <div style={{ padding: 16 }}>
+      <input
+        id="search"
+        value={query}
+        onChange={onChange}
+        placeholder="Search messages..."
+      />
+      <ul id="results">
+        {results.map((m) => (
+          <li key={m.id} onClick={() => copyToClipboard(m.content)}>
+            <b>{m.role}</b>: {m.content.slice(0, 80)}…
+          </li>
+        ))}
+      </ul>
     </div>
   )
 }

--- a/types.ts
+++ b/types.ts
@@ -1,0 +1,14 @@
+export interface Conversation {
+  id: string
+  url: string
+  title?: string
+  createdAt: number
+}
+
+export interface Message {
+  id: string
+  conversationId: string
+  role: "user" | "assistant"
+  content: string
+  createdAt: number
+}


### PR DESCRIPTION
## Summary
- add Conversation and Message interfaces
- implement an IndexedDB wrapper for storing and querying messages
- store scraped messages from ChatGPT into IndexedDB
- add popup search UI to find and copy messages
- include idb and uuid dependencies

## Testing
- `pnpm format`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_686c2b9f3b888331b04cecada0830331